### PR TITLE
lab2/stop/fix

### DIFF
--- a/SpaceBattle.Lib.Test/StrategiesTests/GetPropertyStrategyTest.cs
+++ b/SpaceBattle.Lib.Test/StrategiesTests/GetPropertyStrategyTest.cs
@@ -1,0 +1,20 @@
+using Hwdtech;
+using Hwdtech.Ioc;
+
+using Moq;
+
+namespace SpaceBattle.Lib.Test;
+
+public class GetPropertyStrategyTests
+{
+    [Fact]
+    public void SuccesfulGetPropertyStrategy()
+    {
+        var obj = new Mock<IUObject>();
+        obj.Setup(o => o.getProperty("Speed")).Returns(new Vector(1, 1));
+
+        var strategy = new GetPropertyStrategy();
+
+        Assert.NotNull(strategy.RunStrategy(obj.Object, "Speed"));
+    }
+}

--- a/SpaceBattle.Lib/Strategies/Game.IUObject.GetProperty.cs
+++ b/SpaceBattle.Lib/Strategies/Game.IUObject.GetProperty.cs
@@ -1,0 +1,11 @@
+namespace SpaceBattle.Lib;
+
+public class GetPropertyStrategy : IStrategy
+{
+    public object RunStrategy(params object[] args)
+    {
+        var obj = (IUObject) args[0];
+        var key = (string) args[1];
+        return obj.getProperty(key);
+    }
+}


### PR DESCRIPTION
Вторая лабораторная работа была принята по ошибке (stop command). Нужно было добавить стратегию по получению объекта по ключу у универсального объекта.